### PR TITLE
Add Readme to puzzle

### DIFF
--- a/demos/pySMT_puzzle/README.md
+++ b/demos/pySMT_puzzle/README.md
@@ -1,0 +1,60 @@
+# This is the tutorial example of pySMT
+
+This example shows how to:
+1. Deal with Theory atoms
+2. Specify a solver in the shortcuts (get_model, is_sat etc.)
+3. Obtain an print a model
+
+The goal of the puzzle is to assign a value from 1 to 10 to each letter so that:
+
+H+E+L+L+O = W+O+R+L+D = 25
+
+## How to run the example
+
+The example requires Python 3, and the pysmt package.
+
+You can install pysmt using
+
+```
+$ sudo pip3 install pysmt
+```
+
+Then you may need a solver. You can install z3 using:
+
+```
+$ pysmt-install --z3 --confirm-agreement
+```
+
+Once the installation is finished, you can check that z3 is installed:
+
+```
+$ pysmt-install --check
+Installed Solvers:
+  msat      False (None)              Not in Python's path!
+  cvc4      False (None)              Not in Python's path!
+  z3        True (4.8.7)             
+  yices     False (None)              Not in Python's path!
+  btor      False (None)              Not in Python's path!
+  picosat   False (None)              Not in Python's path!
+  bdd       False (None)              Not in Python's path!
+
+Solvers: z3
+Quantifier Eliminators: z3, shannon, selfsub
+UNSAT-Cores: z3
+Interpolators: 
+```
+
+Now you can run the example:
+
+```
+$ python3 puzzle.py 
+Serialization of the formula:
+((((1 <= h) & (h < 10)) & ((1 <= e) & (e < 10)) & ((1 <= l) & (l < 10)) & ((1 <= o) & (o < 10)) & ((1 <= w) & (w < 10)) & ((1 <= r) & (r < 10)) & ((1 <= d) & (d < 10))) & (((h + e + l + l + o) = (w + o + r + l + d)) & ((h + e + l + l + o) = 25)))
+w := 1
+h := 1
+d := 1
+o := 9
+r := 7
+l := 7
+e := 1
+```

--- a/demos/pySMT_puzzle/README.md
+++ b/demos/pySMT_puzzle/README.md
@@ -1,3 +1,5 @@
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mattvenn/formal-intro-course/blob/master/demos/pySMT_puzzle/pysmt_puzzle.ipynb)
+
 # This is the tutorial example of pySMT
 
 This example shows how to:

--- a/demos/pySMT_puzzle/pysmt_puzzle.ipynb
+++ b/demos/pySMT_puzzle/pysmt_puzzle.ipynb
@@ -1,0 +1,385 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "pysmt_puzzle",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RYm6zt3FrHq5",
+        "colab_type": "text"
+      },
+      "source": [
+        "# This is the tutorial example of pySMT\n",
+        "\n",
+        "This example shows how to:\n",
+        "1. Deal with Theory atoms\n",
+        "2. Specify a solver in the shortcuts (get_model, is_sat etc.)\n",
+        "3. Obtain an print a model\n",
+        "\n",
+        "\n",
+        "The goal of the puzzle is to assign a value from 1 to 10 to each letter so that:\n",
+        "\n",
+        "H+E+L+L+O = W+O+R+L+D = 25\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ZGiPqcy6qnyx",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "465ed59f-2f07-45a2-d490-91273abe6c2a"
+      },
+      "source": [
+        "%load_ext autoreload\n",
+        "%autoreload 2\n",
+        "%matplotlib inline"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "The autoreload extension is already loaded. To reload it, use:\n",
+            "  %reload_ext autoreload\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ooQg2nV9qpqF",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 272
+        },
+        "outputId": "241801a0-6968-44b9-fcdc-647698eacff1"
+      },
+      "source": [
+        "!pip install pysmt\n",
+        "!pysmt-install --z3 --confirm-agreement\n",
+        "!pysmt-install --check"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Requirement already satisfied: pysmt in /usr/local/lib/python3.6/dist-packages (0.9.0)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from pysmt) (1.12.0)\n",
+            "Installed Solvers:\n",
+            "  msat      False (None)              Not in Python's path!\n",
+            "  cvc4      False (None)              Not in Python's path!\n",
+            "  z3        True (4.8.7)             \n",
+            "  yices     False (None)              Not in Python's path!\n",
+            "  btor      False (None)              Not in Python's path!\n",
+            "  picosat   False (None)              Not in Python's path!\n",
+            "  bdd       False (None)              Not in Python's path!\n",
+            "\n",
+            "Solvers: z3\n",
+            "Quantifier Eliminators: z3, shannon, selfsub\n",
+            "UNSAT-Cores: z3\n",
+            "Interpolators: \n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "AS6dCWWbq8jR",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 71
+        },
+        "outputId": "6ae648d4-0883-4f2e-edca-5fd43af8655b"
+      },
+      "source": [
+        "from pysmt.shortcuts import Symbol, And, GE, LT, Plus, Equals, Int, get_model\n",
+        "from pysmt.typing import INT"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /usr/local/lib/python3.6/dist-packages/pysmt/smtlib/parser/parser.py\n",
+            "  tree = Parsing.p_module(s, pxd, full_module_name)\n"
+          ],
+          "name": "stderr"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SlNW7Ycjrofj",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "006b281a-c0bc-4791-b2fa-4f8c8342ce7e"
+      },
+      "source": [
+        "hello = [Symbol(s, INT) for s in \"hello\"]\n",
+        "world = [Symbol(s, INT) for s in \"world\"]\n",
+        "\n",
+        "hello, world"
+      ],
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "([h, e, l, l, o], [w, o, r, l, d])"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 18
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Bxus4q1ur8pL",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "0af0d612-0b9c-4569-c9c5-c840fec08891"
+      },
+      "source": [
+        "letters = set(hello+world)\n",
+        "\n",
+        "letters"
+      ],
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{d, r, w, o, l, e, h}"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 17
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4YbEyCrXrlwE",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "8258f56b-ea56-44d5-80f9-07d846615c86"
+      },
+      "source": [
+        "domains = And([ And(GE(l, Int(1)),LT(l, Int(10))) for l in letters ])\n",
+        "\n",
+        "domains"
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(((1 <= h) & (h < 10)) & ((1 <= e) & (e < 10)) & ((1 <= l) & (l < 10)) & ((1 <= o) & (o < 10)) & ((1 <= w) & (w < 10)) & ((1 <= r) & (r < 10)) & ((1 <= d) & (d < 10)))"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 19
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vGPahTB4rwDj",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "0887e1cc-4307-484c-f0ed-3b35a774cadc"
+      },
+      "source": [
+        "sum_hello = Plus(hello) # n-ary operators can take lists\n",
+        "sum_world = Plus(world) # as arguments\n",
+        "\n",
+        "sum_hello"
+      ],
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(h + e + l + l + o)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 21
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "F8ZKUiq-sW5w",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "80968362-ece1-41bd-9a92-c3dfde218e8e"
+      },
+      "source": [
+        "problem = And(Equals(sum_hello, sum_world), Equals(sum_hello, Int(25)))\n",
+        "\n",
+        "problem"
+      ],
+      "execution_count": 34,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(((h + e + l + l + o) = (w + o + r + l + d)) & ((h + e + l + l + o) = 25))"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 34
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Efm7eiMJtMMH",
+        "colab_type": "text"
+      },
+      "source": [
+        "Serialization of the formula:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "tQ8zKn99sfos",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 54
+        },
+        "outputId": "29581b7b-5a58-4e8d-be09-fd2b9d3a30e9"
+      },
+      "source": [
+        "formula = And(domains, problem)\n",
+        "\n",
+        "formula"
+      ],
+      "execution_count": 35,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "((((1 <= h) & (h < 10)) & ((1 <= e) & (e < 10)) & ((1 <= l) & (l < 10)) & ((1 <= o) & (o < 10)) & ((1 <= w) & (w < 10)) & ((1 <= r) & (r < 10)) & ((1 <= d) & (d < 10))) & (((h + e + l + l + o) = (w + o + r + l + d)) & ((h + e + l + l + o) = 25)))"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 35
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UNgUXu3NtX8N",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 136
+        },
+        "outputId": "23fba3ec-c949-4464-ce83-be56ce18592b"
+      },
+      "source": [
+        "model = get_model(formula)\n",
+        "\n",
+        "if model:\n",
+        "    print(model)\n",
+        "else:\n",
+        "    print(\"No solution found\")"
+      ],
+      "execution_count": 36,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "w := 1\n",
+            "h := 1\n",
+            "d := 5\n",
+            "o := 1\n",
+            "r := 9\n",
+            "l := 9\n",
+            "e := 5\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "wcXhfxVquNrK",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
In this PR I add a Readme to the puzzle.py with info on what the user might need (it was my case: python3, pysmt and install a solver (z3))

I also created a Jupyter Notebook with the example, which can help run interactively the example, and see what happens in every step of the example. For example, it show what "hello" is, what "problem" is...

Finally I have added an "open in collab" svg badge so that anyone can run the example in Google Collab without even installing anything. 

Note: the URL in the badge already points to mattvenn github URL so it will works only if you merge the PR. If you try from my fork, it will fail. (I never found a way to workaround this...)